### PR TITLE
Update bcf-api.ts

### DIFF
--- a/src/bcf-api.ts
+++ b/src/bcf-api.ts
@@ -94,11 +94,10 @@ export class BcfApi {
     return this.http.fetch(this.extendEntrpoint(entrypoint), o);
   }
 
-  public delete(entrypoint: string, body: any = {}, options: RequestOption = {}): Promise < any > {
+  public delete(entrypoint: string, options: RequestOption = {}): Promise < any > {
     this.configureHost();
     let o = this.defaultOptions(options);
     o.method = 'delete';
-    o.body = this.normalizeBody(body, options);
     return this.http.fetch(this.extendEntrpoint(entrypoint), o);
   }
 
@@ -113,7 +112,6 @@ export class BcfApi {
 const bcf = Container.instance.get(AureliaBcf);
 export async function jsonify(response: any): Promise<any> {
   bcf.debug('jsonify:start', response);
-  if (!response || !response.json) return Promise.resolve(response);
   if (response.status === 204) {
     return Promise.resolve({});
   }


### PR DESCRIPTION
Je propose 2 micro modifications sur le bcf-api:
 
- le verbe http DELETE n'a pas de body, il est très similaire au cas du verbe HTTP GET (J'ai par ailleurs vérifié que les consommateurs du delete n'utilisent pas ce paramètre)
- le premier cas traité par la fonction jsonify renvoit une Promise de Promise ( dû au fait que la fonction est async ). Ce cas n'est sans doute jamais utilisé ou alors il ne fonctionne probablement pas... :-)

